### PR TITLE
style: update z-index for buttons agenda components

### DIFF
--- a/components/agenda/CalendarEventCard.vue
+++ b/components/agenda/CalendarEventCard.vue
@@ -41,7 +41,7 @@ const scheduleSize = computed(() => (isMobile.value && !isSmallTablet.value ? 'm
         target="_blank"
         :text="reservationLabel"
         button-class="button-solid-neutral text-[10px] md:text-xs !px-2"
-        class="absolute bottom-2 right-2 z-10"
+        class="absolute bottom-2 right-2 z-2"
       >
         <template #text>
           {{ reservationLabel }}

--- a/components/agenda/CalendarTrends.vue
+++ b/components/agenda/CalendarTrends.vue
@@ -169,7 +169,7 @@ const getTrendButton = (trend: Pick<TrendItem, 'events'>): EventInfoLink | null 
             :href="trend.button.href"
             :target="trend.button.target"
             :text="t(trend.button.text)"
-            :button-class="[getTrendButtonClass(trend.eventType), '!px-2 !py-0.5 !text-xs md:!text-sm absolute bottom-2 right-2 md:bottom-4 z-10']"
+            :button-class="[getTrendButtonClass(trend.eventType), '!px-2 !py-0.5 !text-xs md:!text-sm absolute bottom-2 right-2 md:bottom-4 z-2']"
           >
             <template #icon-right>
               <ArrowRight class="!mt-0" />


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk visual-only change that adjusts stacking order for overlay buttons in agenda cards; potential impact is limited to button layering/overlap in the UI.
> 
> **Overview**
> Reduces the z-index of the bottom-right overlay `FiliButton` in `CalendarEventCard.vue` and `CalendarTrends.vue` from `z-10` to `z-2`, changing how these buttons stack relative to other positioned elements (e.g., headers/overlays) within agenda images.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 99bbec21752993a062c335b4318f801b1f642383. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->