### PR TITLE
fix: add text truncation to event description in CalendarEventCard

### DIFF
--- a/components/agenda/CalendarEventCard.vue
+++ b/components/agenda/CalendarEventCard.vue
@@ -79,7 +79,7 @@ const scheduleSize = computed(() => (isMobile.value && !isSmallTablet.value ? 'm
         aria-hidden="true"
       />
       <p v-if="event.description" class="text-xs mb-0.5 text-white font-medium truncate">
-        <span :class="{ 'line-clamp-1': scheduleSize !== 'large' }">{{ event.description }}</span>
+        {{ event.description }}
       </p>
     </footer>
   </article>

--- a/components/agenda/CalendarEventCard.vue
+++ b/components/agenda/CalendarEventCard.vue
@@ -78,7 +78,7 @@ const scheduleSize = computed(() => (isMobile.value && !isSmallTablet.value ? 'm
         class="flex-shrink-0 text-white !w-3 !h-3"
         aria-hidden="true"
       />
-      <p v-if="event.description" class="text-xs mb-0.5 text-white font-medium">
+      <p v-if="event.description" class="text-xs mb-0.5 text-white font-medium truncate">
         <span :class="{ 'line-clamp-1': scheduleSize !== 'large' }">{{ event.description }}</span>
       </p>
     </footer>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk UI-only change that affects how event descriptions render (single-line truncation) with no data or logic changes.
> 
> **Overview**
> Event descriptions in `CalendarEventCard.vue` are now always *single-line truncated* via Tailwind `truncate`, replacing the prior conditional `line-clamp` behavior based on `scheduleSize`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d606ee5ba8c0c64cbafdd9fb3e3fb5370e4eeb8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->